### PR TITLE
add input validation for /color request

### DIFF
--- a/a30_webserver.ino
+++ b/a30_webserver.ino
@@ -91,8 +91,16 @@ void handleColorGET() {
       server.arg("ratio") + ", brightness:" +
       server.arg("brightness") + ")");
     state = CONSTANTCOLOR;
-    g_ratio = server.arg("ratio").toFloat();
-    g_brightness = server.arg("brightness").toFloat();
+    
+    float ratio = server.arg("ratio").toFloat();
+    if (ratio > 1) ratio = 1;
+    if (ratio < 0) ratio = 0;
+    g_ratio = ratio;
+    
+    float brightness = server.arg("brightness").toFloat();
+    if (brightness > 1.2) brightness = 1.2;
+    if (brightness < 0) brightness = 0;
+    g_brightness = brightness;
   }
 
   root["ratio"] = g_ratio;


### PR DESCRIPTION
I've added input validation for /color as I was able to reset the lamp if I've set both of channels to 255 (haven't checked where is the limit) by setting ratio to 0.5 and brightness to 2. 
I've set the maximum brightness to be 1.2, so you can get it a bit brighter than using the knob. 